### PR TITLE
fix median calculation for odd size sets

### DIFF
--- a/lib/qme/map/cv_aggregator.rb
+++ b/lib/qme/map/cv_aggregator.rb
@@ -6,21 +6,26 @@ module QME
       def self.median(frequencies)
         set_size = frequencies.values.reduce(0, :+)
         offset = set_size.even? ? 1 : 0
-        median_positions = [(set_size / 2), (set_size / 2)+offset]
+        left_position, right_position = [(set_size / 2), (set_size / 2) + offset]
+        current_position = -1 + offset #compensate for integer math flooring
 
-        current_position = 0
         median_left = nil
         median_right = nil
 
         frequencies.keys.sort.each do |value|
-          current_position += frequencies[value]
-          
-          median_left = value if median_left.nil? && current_position >= median_positions[0] 
-          if current_position >= median_positions[1]
-            median_right = value 
+          current_position += (frequencies[value])
+
+          if current_position >= left_position && median_left == nil
+            median_left = value
+            return median_left if set_size.odd?
+          end
+
+          if current_position >= right_position
+            median_right = value
             break
           end
         end
+
         median_left ||= 0
         median_right ||= 0
         (median_left + median_right)/2

--- a/test/unit/qme/map/cv_aggregator_test.rb
+++ b/test/unit/qme/map/cv_aggregator_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class CVAggregatorTest < MiniTest::Unit::TestCase
+
+  def test_median_with_simple_odd_size_set
+    calc({90.0 => 1, 4315.0 => 2}, 4315.0)
+  end
+
+  def test_median_with_complex_odd_size_set
+    calc({0.0 => 5, 25.0 => 2, 50.0 => 8, 100.0 => 6}, 50.0)
+  end
+
+  def test_median_with_simple_even_size_set
+    calc({50.0 => 1, 100.0 => 1}, 75.0)
+  end
+
+  def test_median_with_large_offset_even_size_set
+    calc({1.0 => 3, 2.0 => 1, 5.0 => 1, 7.0 => 1, 8.0 => 1, 10.0 => 2, 12.0 => 1}, 6.0)
+  end
+
+  def test_median_with_complex_even_size_set
+    calc({25.0 => 5, 50.0 => 5, 100.0 => 5, 200.0 => 5}, 75.0)
+  end
+
+  def test_median_with_empty_set
+    calc({}, 0)
+  end
+
+  def test_single_element_set
+    calc({1.0 => 1}, 1.0)
+  end
+
+  def calc(ft, exp)
+    result = QME::MapReduce::CVAggregator.median(ft)
+    assert_equal exp, result
+  end
+end


### PR DESCRIPTION
Median calculation was sometimes incorrect for odd size arrays due to Ruby flooring odd integers when dividing them by two
