### PR TITLE
add the ability to scope measure lookups to bundle id

### DIFF
--- a/lib/qme/map/map_reduce_executor.rb
+++ b/lib/qme/map/map_reduce_executor.rb
@@ -19,7 +19,7 @@ module QME
         @measure_id = measure_id
         @sub_id = sub_id
         @parameter_values = parameter_values
-        @measure_def = QualityMeasure.new(@measure_id, @sub_id).definition
+        @measure_def = QualityMeasure.new(@measure_id, @sub_id, parameter_values['bundle_id']).definition
         determine_connection_information()
       end
 

--- a/lib/qme/quality_measure.rb
+++ b/lib/qme/quality_measure.rb
@@ -6,10 +6,10 @@ module QME
     
     # Return a list of the measures in the database
     # @return [Hash] an hash of measure definitions
-    def self.all
+    def self.all(bundle_id = nil)
       result = {}
-      measures = get_db()['measures']
-      measures.find().each do |measure|
+      measures = query_measures({}, bundle_id)
+      measures.find_all.each do |measure|
         id = measure['id']
         sub_id = measure['sub_id']
         measure_id = "#{id}#{sub_id}.json"
@@ -18,36 +18,44 @@ module QME
       result
     end
     
-    def self.get_measures(measure_ids)
-      get_db()['measures'].find('id' => {"$in" => measure_ids})
+    def self.get_measures(measure_ids, bundle_id = nil)
+      query_measures({'id' => {"$in" => measure_ids}}, bundle_id)
     end
 
-    def self.get(measure_id, sub_id)
-      get_db()['measures'].find('id' => measure_id, 'sub_id' => sub_id)
+    def self.get(measure_id, sub_id, bundle_id = nil)
+      query_measures({'id' => measure_id, 'sub_id' => sub_id}, bundle_id)
     end
 
-    def self.sub_measures(measure_id)
-      get_db()['measures'].find('id' => measure_id)
+    def self.sub_measures(measure_id, bundle_id = nil)
+      query_measures({'id' => measure_id}, bundle_id)
     end
     
     # Creates a new QualityMeasure
     # @param [String] measure_id value of the measure's id field
     # @param [String] sub_id value of the measure's sub_id field, may be nil for measures with only a single numerator and denominator
-    def initialize(measure_id, sub_id = nil)
+    def initialize(measure_id, sub_id = nil, bundle_id = nil)
       @measure_id = measure_id
       @sub_id = sub_id
+      @bundle_id = bundle_id
       determine_connection_information
     end
     
     # Retrieve a measure definition from the database
     # @return [Hash] a JSON hash of the encoded measure
     def definition
-      measures = get_db()['measures']
       if @sub_id
-        measures.find({'id' => @measure_id, 'sub_id' => @sub_id}).first()
+        QME::QualityMeasure.query_measures({'id' => @measure_id, 'sub_id' => @sub_id}, @bundle_id).first()
       else
-        measures.find({'id' => @measure_id}).first()
+        QME::QualityMeasure.query_measures({'id' => @measure_id}, @bundle_id).first()
       end
+    end
+
+    # Build measure collection query. Allows scoping of query to a single bundle
+    # @param [String] criteria Moped query hash
+    # @param [String] bundle_id the MongoDB id of the bundle to scope the query against. Leaving this as nil will scope to all bundles
+    def self.query_measures(criteria, bundle_id=nil)
+      criteria = bundle_id ? criteria.merge!({'bundle_id' => bundle_id}): criteria
+      get_db()['measures'].find(criteria)
     end
   end
 end

--- a/test/unit/qme/map/map_reduce_executor_test.rb
+++ b/test/unit/qme/map/map_reduce_executor_test.rb
@@ -96,4 +96,16 @@ class MapReduceExecutorTest < MiniTest::Unit::TestCase
     assert_equal 0, get_db['patient_cache'].find().count
     assert result[QME::QualityReport::NUMERATOR]
   end
+
+  def test_get_patient_result_with_bundle_id
+    measure_id = "2E679CD2-3FEC-4A75-A75A-61403E5EFEE8"
+    bundle_id = get_db()['bundles'].find.first
+    get_db()['measures'].find('id' => measure_id).update(:$set => {'bundle_id' => bundle_id})
+    executor = QME::MapReduce::Executor.new(measure_id, nil,
+                                            'effective_date' => Time.gm(2011, 1, 15).to_i, 'bundle_id' => bundle_id)
+    result = executor.get_patient_result("12345")
+    assert_equal 0, get_db['patient_cache'].find().count
+    assert result[QME::QualityReport::NUMERATOR]
+  end
+
 end

--- a/test/unit/qme/quality_measure_test.rb
+++ b/test/unit/qme/quality_measure_test.rb
@@ -2,16 +2,51 @@ require 'test_helper'
 
 class QualityMeasureTest < MiniTest::Unit::TestCase
 	include QME::DatabaseAccess
-  def setup
 
+  def setup
     collection_fixtures(get_db(), 'measures')
     collection_fixtures(get_db(), 'bundles')
+    @bundle_id = get_db['bundles'].find.first['_id']
+    get_db['measures'].find({}).update(:$set => {'bundle_id' => @bundle_id})
     load_system_js
   end
 
-  def test_getting_all_measures
+  def test_getting_all_measures_without_bundle_id
     all_measures = QME::QualityMeasure.all
     assert_equal 5, all_measures.size
+
     assert all_measures["2E679CD2-3FEC-4A75-A75A-61403E5EFEE8.json"]
   end
+
+  def test_getting_definition_with_bundle_id
+    result = QME::QualityMeasure.all(@bundle_id).to_a.first.last
+    measure = QME::QualityMeasure.new(result['id'], result['sub_id'], @bundle_id)
+    assert measure.definition
+    assert_equal result['id'], measure.definition['id']
+  end
+
+  def test_getting_all_measure_with_bundle_id
+    get_db()['measures']
+    all_measures = QME::QualityMeasure.all(@bundle_id)
+
+    assert_equal 1, all_measures.size
+  end
+
+  def test_getting_measure_subset
+    measure_ids = get_db['measures'].find({}).map { |m| m['id'] }
+    measure_ids.pop
+    measures = QME::QualityMeasure.get_measures(measure_ids)
+    assert_equal 4, measures.count
+  end
+
+  def test_getting_sub_measures
+    measures = QME::QualityMeasure.sub_measures("8A4D92B2-3887-5DF3-0139-0C4E41594C98")
+    assert_equal 2, measures.count
+  end
+
+  def test_getting_sub_measure
+    measure = QME::QualityMeasure.get("8A4D92B2-3887-5DF3-0139-0C4E41594C98", 'a')
+    assert measure
+  end
+
 end


### PR DESCRIPTION
Adds an optional parameter to QME::QualityMeasure queries and Map/Reduce jobs which allows you to scope the measure lookup to a specific bundle id.
