### PR TITLE
Fix Bundle scoping test

### DIFF
--- a/test/unit/qme/quality_measure_test.rb
+++ b/test/unit/qme/quality_measure_test.rb
@@ -35,8 +35,10 @@ class QualityMeasureTest < MiniTest::Unit::TestCase
   def test_getting_measure_subset
     measure_ids = get_db['measures'].find({}).map { |m| m['id'] }
     measure_ids.pop
+    
     measures = QME::QualityMeasure.get_measures(measure_ids)
-    assert_equal 4, measures.count
+    measure_ids2 = measures.map { |m| m['id'] }
+    assert_equal measure_ids.sort, measure_ids2.sort
   end
 
   def test_getting_sub_measures

--- a/test/unit/qme/quality_measure_test.rb
+++ b/test/unit/qme/quality_measure_test.rb
@@ -35,10 +35,9 @@ class QualityMeasureTest < MiniTest::Unit::TestCase
   def test_getting_measure_subset
     measure_ids = get_db['measures'].find({}).map { |m| m['id'] }
     measure_ids.pop
-    
     measures = QME::QualityMeasure.get_measures(measure_ids)
     measure_ids2 = measures.map { |m| m['id'] }
-    assert_equal measure_ids.sort, measure_ids2.sort
+    assert_equal [], measure_ids - measure_ids2
   end
 
   def test_getting_sub_measures


### PR DESCRIPTION
My test was bad, and I should feel bad. (\/) (°,,,°) (\/) 

(It wasn't the ternary operator though, the test didn't handle submeasures well. MongoDB 2.4 changed the default sorting and that messed up the test. Now it compares the two arrays as sets, which better matches the intended behavior)
