### PR TITLE
marking initailzer of QualityReport as a protected method.  Previous ver...

### DIFF
--- a/lib/qme/quality_report.rb
+++ b/lib/qme/quality_report.rb
@@ -183,6 +183,13 @@ module QME
 
     protected
 
+     #In the older version of QME QualityReport was not treated as apersisted object. As
+     # a result anytime you wanted to get the cached results for a calculation you would create
+     # a new QR object which would then go to the db and see if the calculation was performed or
+     # not yet and then return the results.  now that QR objects are persisted you need to go through
+     # the find_or_create by method to ensure that duplicate entries are not being created.  Protecting
+     # this method causes an exception to be thrown for anyone attempting to use this version of QME with the 
+     # sematics of the older version to highlight the issue
     def initialize(attrs = nil, options = nil)
       super(attrs, options)
     end

--- a/lib/qme/quality_report.rb
+++ b/lib/qme/quality_report.rb
@@ -153,36 +153,38 @@ module QME
     end
 
 
-  def patient_cache_matcher
-    match = {'value.measure_id' => self.measure_id, 
-             'value.sub_id'           => self.sub_id,
-             'value.effective_date'   => self.effective_date,
-             'value.test_id'          => test_id,
-             'value.manual_exclusion' => {'$in' => [nil, false]}}
+    def patient_cache_matcher
+      match = {'value.measure_id' => self.measure_id, 
+               'value.sub_id'           => self.sub_id,
+               'value.effective_date'   => self.effective_date,
+               'value.test_id'          => test_id,
+               'value.manual_exclusion' => {'$in' => [nil, false]}}
 
-    if(filters)
-      if (filters['races'] && filters['races'].size > 0)
-        match['value.race.code'] = {'$in' => filters['races']}
+      if(filters)
+        if (filters['races'] && filters['races'].size > 0)
+          match['value.race.code'] = {'$in' => filters['races']}
+        end
+        if (filters['ethnicities'] && filters['ethnicities'].size > 0)
+          match['value.ethnicity.code'] = {'$in' => filters['ethnicities']}
+        end
+        if (filters['genders'] && filters['genders'].size > 0)
+          match['value.gender'] = {'$in' => filters['genders']}
+        end
+        if (filters['providers'] && filters['providers'].size > 0)
+          providers = filters['providers'].map { |pv| Moped::BSON::ObjectId(pv) }
+          match['value.provider_performances.provider_id'] = {'$in' => providers}
+        end
+        if (filters['languages'] && filters['languages'].size > 0)
+          match["value.languages"] = {'$in' => filters['languages']}
+        end
       end
-      if (filters['ethnicities'] && filters['ethnicities'].size > 0)
-        match['value.ethnicity.code'] = {'$in' => filters['ethnicities']}
-      end
-      if (filters['genders'] && filters['genders'].size > 0)
-        match['value.gender'] = {'$in' => filters['genders']}
-      end
-      if (filters['providers'] && filters['providers'].size > 0)
-        providers = filters['providers'].map { |pv| Moped::BSON::ObjectId(pv) }
-        match['value.provider_performances.provider_id'] = {'$in' => providers}
-      end
-      if (filters['languages'] && filters['languages'].size > 0)
-        match["value.languages"] = {'$in' => filters['languages']}
-      end
+      match
     end
-    match
+
+    protected
+
+    def initialize(attrs = nil, options = nil)
+      super(attrs, options)
+    end
   end
-
-
-  end
-
-
 end


### PR DESCRIPTION
...sions of QME used QualityReport as a facade around the query cache entries.  This version uses mongoid and treats the reports as first class objects so we need to ensure that they are first searched for and then created as a last resort if they do not exist.  Protecting the initializer will cause errors in applications attempting to use this updated version of the code with older semantics and alter the users to issues that they will need to address in their own codebase.  Also contains a bit of reformatting .
