### PR TITLE
Fixes the creation of the BSON::ObjectId

### DIFF
--- a/lib/qme/map/map_reduce_executor.rb
+++ b/lib/qme/map/map_reduce_executor.rb
@@ -52,7 +52,7 @@ module QME
             match['value.gender'] = {'$in' => filters['genders']}
           end
           if (filters['providers'] && filters['providers'].size > 0)
-            providers = filters['providers'].map { |pv| {'providers' => BSON::ObjectId(pv) } }
+            providers = filters['providers'].map { |pv| {'providers' => BSON::ObjectId.from_string(pv) } }
             pipeline.concat [{'$project' => {'value' => 1, 'providers' => "$value.provider_performances.provider_id"}}, 
                              {'$unwind' => '$providers'}, 
                              {'$match' => {'$or' => providers}},


### PR DESCRIPTION
The latest version of Moped moves away from its own implementation of
BSON and switches back to the default. With this change, there are
some API changes. This is a spot where we are trying to create a BSON
ObjectId through the old API, where we need to use from_string.
