### PR TITLE
Fix provider assignment

### DIFF
--- a/lib/qme/map/map_reduce_builder.rb
+++ b/lib/qme/map/map_reduce_builder.rb
@@ -119,7 +119,9 @@ module QME
                         // Late Overlap
                         ((value['start_date'] < #{@params['effective_date']}) && (value['end_date'] >= #{@params['effective_date']} || value['end_date'] == null)) ||
                         // Full Overlap
-                        ((value['start_date'] <= #{reporting_period_start} || value['start_date'] == null) && (value['end_date'] >= #{@params['effective_date']} || value['end_date'] == null))
+                        ((value['start_date'] <= #{reporting_period_start} || value['start_date'] == null) && (value['end_date'] >= #{@params['effective_date']} || value['end_date'] == null)) ||
+                        // Full Containment
+                        (value['start_date'] > #{reporting_period_start} && value['end_date'] < #{@params['effective_date']})
                        )
                        tmp.push(value);
                      }

--- a/lib/qme/map/map_reduce_builder.rb
+++ b/lib/qme/map/map_reduce_builder.rb
@@ -125,8 +125,12 @@ module QME
                        )
                        tmp.push(value);
                      }
-                     if (tmp.length == 0) tmp = null;
-                     patient.provider_performances = tmp;
+                     if (tmp.length > 0) {
+                        patient.provider_performances = tmp;
+                     } else {
+                        sortedProviders = _.sortBy(patient.provider_performances, function(performance){return performance['end_date']});
+                        patient.provider_performances = [_.last(sortedProviders)];
+                     }
                    }
                    return patient;}"
 

--- a/lib/qme/map/map_reduce_builder.rb
+++ b/lib/qme/map/map_reduce_builder.rb
@@ -3,7 +3,7 @@ require 'ostruct'
 
 module QME
   module MapReduce
-  
+
     # Builds Map and Reduce functions for a particular measure
     class Builder
       attr_reader :id, :params
@@ -11,19 +11,19 @@ module QME
       # Utility class used to supply a binding to Erb
       class Context < OpenStruct
         # Create a new context
-        # @param [Hash] vars a hash of parameter names (String) and values (Object). Each 
+        # @param [Hash] vars a hash of parameter names (String) and values (Object). Each
         # entry is added as an accessor of the new Context
         def initialize(db, vars)
           super(Context.add_defaults(vars))
           @db = db
         end
-      
+
         # Get a binding that contains all the instance variables
         # @return [Binding]
         def get_binding
           binding
         end
-        
+
         # Add default parameter values if not specified
         def self.add_defaults(vars)
           if !vars.has_key?('enable_logging')
@@ -34,7 +34,7 @@ module QME
           end
           vars
         end
-        
+
         # Inserts any library code into the measure JS. JS library code is loaded from
         # three locations: the js directory of the quality-measure-engine project, the
         # js sub-directory of the current directory (e.g. measures/js), and the bundles
@@ -60,7 +60,7 @@ module QME
         @id = measure_def['id']
         @params = {}
         @db = db
-        
+
         # normalize parameters hash to accept either symbol or string keys
         params.each do |name, value|
           @params[name.to_s] = value
@@ -93,8 +93,8 @@ module QME
       # map-reduce-utils.js
       # @return [String] the reduce function
       def finalize_function
-        reduce = 
-        "function (key, value) { 
+        reduce =
+        "function (key, value) {
           var patient = value;
           patient.measure_id = \"#{@measure_def['id']}\";\n"
         if @params['test_id'] && @params['test_id'].class==BSON::ObjectId
@@ -106,7 +106,7 @@ module QME
         if @measure_def.nqf_id
           reduce += "  patient.nqf_id = \"#{@measure_def.nqf_id}\";\n"
         end
-          
+
         reduce += "patient.effective_date = #{@params['effective_date']};
                    if (patient.provider_performances) {
                      var tmp = [];
@@ -119,7 +119,7 @@ module QME
                      patient.provider_performances = tmp;
                    }
                    return patient;}"
-        
+
         reduce
       end
 

--- a/test/fixtures/records/barry_berry.json
+++ b/test/fixtures/records/barry_berry.json
@@ -446,7 +446,7 @@
       "codes": {
         "SNOMED-CT": [
           "273447005"
-        ]        
+        ]
       },
       "start_time": 1269762691,
       "end_time": 1269762693,
@@ -462,11 +462,18 @@
       "codes": {
         "SNOMED-CT": [
           "273447005"
-        ]        
+        ]
       },
       "start_time": 1269762691,
       "end_time": 1269762693,
       "anatomicalStructure" : {"code": "13648007", "codeSystem": "SNOMED-CT"}
+    }
+  ],
+  "provider_performances" : [
+    {
+      "start_date" : 946684800,
+      "end_date" : 1291161600,
+      "provider_id" : "early_overlap"
     }
   ]
 }

--- a/test/fixtures/records/billy_jones_ipp.json
+++ b/test/fixtures/records/billy_jones_ipp.json
@@ -75,5 +75,12 @@
                 ]
             }
         }
+    ],
+    "provider_performances" : [
+        {
+            "start_date" : 1291161600,
+            "end_date" : 1417392000,
+            "provider_id" : "late_overlap"
+        }
     ]
 }

--- a/test/fixtures/records/jane_jones_numerator.json
+++ b/test/fixtures/records/jane_jones_numerator.json
@@ -82,6 +82,13 @@
             }
         }
     ],
+    "provider_performances" : [
+        {
+            "start_date" : 946684800,
+            "end_date" : 978307200,
+            "provider_id" : "too_early_provider"
+        }
+    ],
     "vital_signs": [
         {
             "codes": {

--- a/test/fixtures/records/jane_jones_numerator.json
+++ b/test/fixtures/records/jane_jones_numerator.json
@@ -84,6 +84,11 @@
     ],
     "provider_performances" : [
         {
+            "start_date" : 2,
+            "end_date" : 7200,
+            "provider_id" : "waaay_too_early_provider"
+        },
+        {
             "start_date" : 946684800,
             "end_date" : 978307200,
             "provider_id" : "too_early_provider"

--- a/test/fixtures/records/jill_jones_denominator.json
+++ b/test/fixtures/records/jill_jones_denominator.json
@@ -81,5 +81,12 @@
                 ]
             }
         }
+    ],
+    "provider_performances" : [
+        {
+            "start_date" : 946684800,
+            "end_date" : 1417392000,
+            "provider_id" : "late_overlap"
+        }
     ]
 }

--- a/test/unit/qme/map/map_reduce_executor_test.rb
+++ b/test/unit/qme/map/map_reduce_executor_test.rb
@@ -19,9 +19,9 @@ class MapReduceExecutorTest < MiniTest::Unit::TestCase
   def test_map_records_into_measure_groups
     executor = QME::MapReduce::Executor.new(@quality_report.measure_id,@quality_report.sub_id, {
                                             'effective_date' => Time.gm(2011, 1, 15).to_i})
-                                            
+
     executor.map_records_into_measure_groups
-    
+
 
     assert_equal 4, get_db['patient_cache'].find().count
     assert_equal 3, get_db['patient_cache'].find("value.#{QME::QualityReport::POPULATION}" => 1).count
@@ -31,13 +31,13 @@ class MapReduceExecutorTest < MiniTest::Unit::TestCase
   end
 
 
- def test_calculate_supplemental_data_elements
+  def test_calculate_supplemental_data_elements
     executor = QME::MapReduce::Executor.new(@quality_report.measure_id,@quality_report.sub_id, {
                                             'effective_date' => Time.gm(2011, 1, 15).to_i})
-                                            
+
     executor.map_records_into_measure_groups
     result = executor.count_records_in_measure_groups
-    
+
     suppl = result["supplemental_data"]
 
     assert !suppl.empty?, "should contain supplemental data entries"
@@ -59,13 +59,13 @@ class MapReduceExecutorTest < MiniTest::Unit::TestCase
      QME::QualityReport::SEX => {"F"=>1}
      }
 
-     
+
 
     assert_equal ipp, suppl[QME::QualityReport::POPULATION]
     assert_equal denom, suppl[QME::QualityReport::DENOMINATOR]
     assert_equal numer, suppl[QME::QualityReport::NUMERATOR]
 
-   
+
   end
 
   def test_count_records_in_measure_groups
@@ -79,7 +79,7 @@ class MapReduceExecutorTest < MiniTest::Unit::TestCase
 
     executor = QME::MapReduce::Executor.new(@quality_report.measure_id,@quality_report.sub_id, {
                                             'effective_date' => Time.gm(2011, 1, 14).to_i})
- 
+
     result = executor.count_records_in_measure_groups
     assert_equal 0, result[QME::QualityReport::POPULATION]
     assert_equal 0, result[QME::QualityReport::DENOMINATOR]
@@ -104,6 +104,13 @@ class MapReduceExecutorTest < MiniTest::Unit::TestCase
     result = executor.get_patient_result("12345")
     assert_equal 0, QME::PatientCache.count
     assert result[QME::QualityReport::NUMERATOR]
+  end
+
+  def test_provider_assignment
+    executor = QME::MapReduce::Executor.new(@quality_report.measure_id,@quality_report.sub_id, {
+                                            'effective_date' => Time.gm(2011, 1, 15).to_i})
+    executor.map_records_into_measure_groups
+    assert_equal 3, get_db['patient_cache'].find("value.provider_performances" => {'$size' => 1}).count
   end
 
   def test_get_patient_result_with_bundle_id

--- a/test/unit/qme/map/map_reduce_executor_test.rb
+++ b/test/unit/qme/map/map_reduce_executor_test.rb
@@ -110,7 +110,8 @@ class MapReduceExecutorTest < MiniTest::Unit::TestCase
     executor = QME::MapReduce::Executor.new(@quality_report.measure_id,@quality_report.sub_id, {
                                             'effective_date' => Time.gm(2011, 1, 15).to_i})
     executor.map_records_into_measure_groups
-    assert_equal 3, get_db['patient_cache'].find("value.provider_performances" => {'$size' => 1}).count
+    assert_equal 4, get_db['patient_cache'].find("value.provider_performances" => {'$size' => 1}).count
+    assert_equal 1, QME::PatientCache.where('value.medical_record_id' => '12345', 'value.provider_performances.provider_id' => 'too_early_provider').count
   end
 
   def test_get_patient_result_with_bundle_id


### PR DESCRIPTION
Fixes how providers get assigned to patient_cache documents. Now if a provider performance in any way overlaps with or is wholly contained in the reporting period, it will be assigned to the patient_cache document.

If there are no active providers during the reporting period, the last provider (one with the latest end_date) will be assigned to the result.
