### PR TITLE
Needed changes to QualityReport and MeasureCalculationJob to work with Cypress 2.5

### DIFF
--- a/lib/qme/map/measure_calculation_job.rb
+++ b/lib/qme/map/measure_calculation_job.rb
@@ -19,7 +19,6 @@ module QME
       end
 
       def perform
-
         if !@quality_report.calculated?
           map = QME::MapReduce::Executor.new(@quality_report.measure_id,@quality_report.sub_id, @options.merge('start_time' => Time.now.to_i))
           if !@quality_report.patients_cached?
@@ -42,6 +41,7 @@ module QME
           completed("#{@measure_id}#{@sub_id}: p#{result[QME::QualityReport::POPULATION]}, d#{result[QME::QualityReport::DENOMINATOR]}, n#{result[QME::QualityReport::NUMERATOR]}, excl#{result[QME::QualityReport::EXCLUSIONS]}, excep#{result[QME::QualityReport::EXCEPTIONS]}")
           QME::QualityReport.queue_staged_rollups(@quality_report.measure_id,@quality_report.sub_id,@quality_report.effective_date)
         end
+        @quality_report
       end
 
       def completed(message)


### PR DESCRIPTION
The change in `MeasureCalculationJob.rb` makes the perform method return the calculated quality report. This is so we can get back the quality report without having to refresh it from the DB in Cypress. If this is non-optimal, or breaks other code (though I looked and didn't see anywhere that it would), this change can be rejected and Cypress can be rewritten.

The change to `QualityReport` adds a test_id when searching the database for already-calculated or queued `QualityReports`, which keeps the code from seeing reports calculated for non-related tests with different test IDs. The former code was generating false-positives in Cypress when a test was calculating; it would find the results imported from the bundle.

The whitespace "cleanup" was an automatic Atom thing, apologies for the pull request clutter.
