### PR TITLE
bumping version to 3.1.2  it may look as though nothing happened in this...

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    quality-measure-engine (3.1.1)
+    quality-measure-engine (3.1.2)
       delayed_job_mongoid (~> 2.1.0)
       mongoid (~> 4.0.0)
       moped (~> 2.0.0)

--- a/lib/qme/version.rb
+++ b/lib/qme/version.rb
@@ -1,3 +1,3 @@
 module QME
-  VERSION = "3.1.1"
+  VERSION = "3.1.2"
 end


### PR DESCRIPTION
... version update but local files inadvertantly were contained in the 3.1.1 gem release that were not meant for inclusion in the gem release.  This caused supplmental data calculation to be commented out and not executed.
